### PR TITLE
Changed 'csharp' to 'dotnet' in the URL

### DIFF
--- a/tech/languages/csharp/dotnet-installation.html
+++ b/tech/languages/csharp/dotnet-installation.html
@@ -150,7 +150,7 @@
 </div>
             </div>
           </div>
-          <a target="_blank" href="https://github.com/developer-portal/content/edit/master/tech/languages/csharp/about.md" class="btn btn-default">Edit this page</a>
+          <a target="_blank" href="https://github.com/developer-portal/content/edit/master/tech/languages/dotnet/about.md" class="btn btn-default">Edit this page</a>
           <a target="_blank" href="https://github.com/developer-portal/content/issues/new?title=tech-languages:+dotnet+about.md&body=Describe+the+problem" class="btn btn-default">Report an issue</a>
         </div>
         <div class="col-sm-9">


### PR DESCRIPTION
Changed 'csharp' to 'dotnet' in the URL leading to the code on GitHub, as the 'csharp' folder was renamed to 'dotnet'.